### PR TITLE
Prevent client reinitialization

### DIFF
--- a/th2c/client.py
+++ b/th2c/client.py
@@ -46,6 +46,10 @@ class AsyncHTTP2Client(object):
                  _connection_cls=HTTP2ClientConnection,
                  _stream_cls=HTTP2ClientStream):
 
+        if getattr(self, 'initialized', False):
+            return
+        else:
+            self.initialized = True
         self.io_loop = io_loop or IOLoop.instance()
 
         self.host = host


### PR DESCRIPTION
Client __init__ is executed every time a new client is instantiated, although the instances should act as singletons.
