### PR TITLE
Go HTTP/2 setup

### DIFF
--- a/vm/provision.sh
+++ b/vm/provision.sh
@@ -5,6 +5,7 @@ apt-get install -y python python-dev python-pip
 apt-get install -y golang-go
 
 cd /opt/dev/th2c
+mkdir logs
 pip install -r requirements.txt
 
 # set GOPATH

--- a/vm/provision.sh
+++ b/vm/provision.sh
@@ -8,7 +8,8 @@ cd /opt/dev/th2c
 pip install -r requirements.txt
 
 # set GOPATH
-echo "export GOPATH=/opt/dev/goworkspace/" > /etc/profile.d/gopath.sh
+GOPATH=/opt/dev/goworkspace
+echo "GOPATH=$GOPATH" > "/etc/environment"
 
 # get the http2 package
 go get golang.org/x/net/http2

--- a/vm/provision.sh
+++ b/vm/provision.sh
@@ -6,3 +6,9 @@ apt-get install -y golang-go
 
 cd /opt/dev/th2c
 pip install -r requirements.txt
+
+# set GOPATH
+echo "export GOPATH=/opt/dev/goworkspace/" > /etc/profile.d/gopath.sh
+
+# get the http2 package
+go get golang.org/x/net/http2


### PR DESCRIPTION
For more HTTP/2 settings, the `golang.org/x/net/http2` is needed. 
Export GOPATH and install the http2 package in provision.sh