### PR TITLE
Fixed issues related to MAX_CONCURRENT_STREAMS

### DIFF
--- a/th2c/connection.py
+++ b/th2c/connection.py
@@ -328,6 +328,10 @@ class HTTP2ClientConnection(object):
             log.debug(['PROCESSING EVENT', event])
             stream_id = getattr(event, 'stream_id', None)
 
+            if type(event) in self.event_handlers:
+                for ev_handler in self.event_handlers[type(event)]:
+                    ev_handler(event)
+
             if isinstance(event, h2.events.DataReceived):
                 recv_streams[stream_id] = (recv_streams.get(stream_id, 0) +
                                            event.flow_controlled_length)
@@ -347,10 +351,6 @@ class HTTP2ClientConnection(object):
                         stream.handle_exception
                 ):
                     stream.handle_event(event)
-
-            if type(event) in self.event_handlers:
-                for ev_handler in self.event_handlers[type(event)]:
-                    ev_handler(event)
 
         recv_connection = 0
         for stream_id, num_bytes in recv_streams.iteritems():


### PR DESCRIPTION
On settings received, call the registered event handlers before
processing the settings on the connection object.
This delays sending streams until the client acknowledges the
MAX_CONCURRENT_STREAMS value sent by the other side.

Fixes #22 